### PR TITLE
feat: add support for voices/users usage stats

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -7,7 +7,12 @@ export {
   HttpError,
   Api,
 } from "grammy/mod.ts";
-export type { InlineQueryResultVoice, BotCommand } from "grammy/types.ts";
+export type { InlineQueryResultVoice, BotCommand, User } from "grammy/types.ts";
 export { run, type RunnerHandle, sequentialize } from "grammy_runner/mod.ts";
 export { load as dotenv } from "dotenv/mod.ts";
-export { Bson, MongoClient, type ObjectId } from "mongo/mod.ts";
+export {
+  Bson,
+  MongoClient,
+  type ObjectId,
+  type Collection,
+} from "mongo/mod.ts";

--- a/src/database/updateStats.ts
+++ b/src/database/updateStats.ts
@@ -1,0 +1,53 @@
+import { client } from "@/bot.ts";
+import { User } from "@/deps.ts";
+
+import { VoiceStatsSchema } from "@/src/schemas/voiceStats.ts";
+import { UsersStatsSchema } from "@/src/schemas/usersStats.ts";
+import { extractUserDetails } from "@/src/helpers/api.ts";
+import { rootCacheKey } from "@/src/constants.ts";
+import { rootQueryCache } from "@/src/handlers/inlineQuery.ts";
+
+export async function updateVoiceStats(voiceID: string) {
+  const db = client.database("deko");
+  const voiceStats = db.collection<VoiceStatsSchema>("voiceStats");
+  const { id, title } = rootQueryCache
+    .get(rootCacheKey)!
+    .find((data) => data.id === voiceID)!;
+
+  await voiceStats.findAndModify(
+    { id },
+    {
+      update: {
+        $set: {
+          id,
+          title,
+        },
+        $inc: {
+          usesAmount: 1,
+        },
+      },
+      upsert: true,
+    }
+  );
+}
+
+export async function updateUsersStats(from: User) {
+  const db = client.database("deko");
+  const userDetails = extractUserDetails(from);
+  const usersStats = db.collection<UsersStatsSchema>("usersStats");
+
+  await usersStats.findAndModify(
+    { userID: userDetails.userID },
+    {
+      update: {
+        $set: {
+          ...userDetails,
+        },
+        $inc: {
+          usesAmount: 1,
+        },
+      },
+      upsert: true,
+    }
+  );
+}

--- a/src/handlers/inlineQuery.ts
+++ b/src/handlers/inlineQuery.ts
@@ -12,6 +12,10 @@ import {
   rootCacheTime,
   textCacheTime,
 } from "@/src/constants.ts";
+import {
+  updateUsersStats,
+  updateVoiceStats,
+} from "@/src/database/updateStats.ts";
 
 export const rootQueryCache = new TTLCache<
   typeof rootCacheKey,
@@ -27,6 +31,11 @@ export const textQueryCache = new TTLCache<string, InlineQueryResultVoice[]>({
 });
 
 const inlineQueryHandler = new Composer();
+
+inlineQueryHandler.on("chosen_inline_result", async (ctx) => {
+  const { from, result_id: voiceID } = ctx.update.chosen_inline_result;
+  await Promise.all([updateVoiceStats(voiceID), updateUsersStats(from)]);
+});
 
 inlineQueryHandler.on("inline_query", async (ctx) => {
   const currentOffset = Number(ctx.update.inline_query.offset) || 0;

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -1,6 +1,7 @@
-import { Api } from "@/deps.ts";
+import { Api, User } from "@/deps.ts";
 
 import { creatorCommands } from "@/src/constants.ts";
+import { getFullName } from "@/src/helpers/general.ts";
 
 /**
  * Registers commands for creator
@@ -19,4 +20,20 @@ export async function registerCreatorCommands(api: Api, creatorID?: string) {
       chat_id: Number(creatorID),
     },
   });
+}
+
+/**
+ * Extracts essential fields from user object
+ *
+ * @param ctx User object
+ * @returns Object with user's id, full name and username
+ */
+export function extractUserDetails(from: User) {
+  const { id, first_name, last_name, username } = from;
+
+  return {
+    userID: id,
+    fullName: getFullName(first_name, last_name),
+    username,
+  };
 }

--- a/src/helpers/general.ts
+++ b/src/helpers/general.ts
@@ -13,3 +13,17 @@ export function convertGoogleDriveLink(link: string) {
   if (!fileId) throw new Error(googleExportLinkFail);
   return `${googleExportDownloadLink}${fileId}`;
 }
+
+/**
+ * Returns full name of user, based on availability of last name
+ *
+ * If last name is present, combines it with first name, otherwise returns only first name as is
+ *
+ * @param firstName First name of user
+ * @param lastName Last name of user
+ * @returns Full name of user
+ */
+export function getFullName(firstName: string, lastName?: string) {
+  if (!lastName) return firstName;
+  return `${firstName} ${lastName}`;
+}

--- a/src/schemas/usersStats.ts
+++ b/src/schemas/usersStats.ts
@@ -1,0 +1,9 @@
+import { ObjectId } from "@/deps.ts";
+
+export interface UsersStatsSchema {
+  _id: ObjectId;
+  userID: number;
+  username?: string;
+  fullName?: string;
+  usesAmount: number;
+}

--- a/src/schemas/voiceStats.ts
+++ b/src/schemas/voiceStats.ts
@@ -1,0 +1,8 @@
+import { ObjectId } from "@/deps.ts";
+
+export interface VoiceStatsSchema {
+  _id: ObjectId;
+  id: string;
+  title: string;
+  usesAmount: number;
+}


### PR DESCRIPTION
Now, by listening to `chosen_inline_result` event, bot will store statistics of voice usage (which voice lines were chosen most often) and users (which user chose voice lines most often)

What about privacy? As data for user statistics, bot will store user's ID, full name (a combination of first and last name) and username

> At the moment, there is no option to opt out of storing statistics for a user. It will be added in the future