### PR TITLE
refactor: move voice uses stats directly to voice data

### DIFF
--- a/src/constants/database.ts
+++ b/src/constants/database.ts
@@ -9,7 +9,6 @@ export const collectionNames = {
     },
     [databaseNames.deko]: {
         voices: "voices",
-        voiceStats: "voiceStats",
         usersStats: "usersStats",
     },
 } as const;

--- a/src/database/deko/stats/updateStats.ts
+++ b/src/database/deko/stats/updateStats.ts
@@ -1,45 +1,29 @@
 import { client } from "@/bot.ts";
 import { User } from "@/deps.ts";
 
-import { rootCacheKey } from "@/src/constants/cache.ts";
 import { collectionNames, databaseNames } from "@/src/constants/database.ts";
-import { rootQueryCache } from "@/src/cache/rootQuery.ts";
 import { extractUserDetails } from "@/src/helpers/api.ts";
-import { VoiceStatsSchema } from "@/src/schemas/voiceStats.ts";
 import { UsersStatsSchema } from "@/src/schemas/usersStats.ts";
+import { VoiceSchema } from "@/src/schemas/voice.ts";
 
 const dbName = databaseNames.deko;
-const voiceColName = collectionNames[dbName].voiceStats;
+const voicesColName = collectionNames[dbName].voices;
 const usersColName = collectionNames[dbName].usersStats;
 
-export async function updateVoiceStats(voiceID: string) {
-    const db = client.database(dbName);
-    const voiceStats = db.collection<VoiceStatsSchema>(voiceColName);
-    const { id, title } = rootQueryCache
-        .get(rootCacheKey)!
-        .find((data) => data.id === voiceID)!;
-
-    await voiceStats.findAndModify(
-        { id },
-        {
-            update: {
-                $set: {
-                    id,
-                    title,
-                },
-                $inc: {
-                    usesAmount: 1,
-                },
-            },
-            upsert: true,
-        },
-    );
-}
-
-export async function updateUsersStats(from: User) {
+export async function updateStats(voiceID: string, from: User) {
     const db = client.database(dbName);
     const userDetails = extractUserDetails(from);
     const usersStats = db.collection<UsersStatsSchema>(usersColName);
+    const voicesCol = db.collection<VoiceSchema>(voicesColName);
+
+    await voicesCol.updateOne(
+        { id: voiceID },
+        {
+            $inc: {
+                usesAmount: 1,
+            },
+        },
+    );
 
     await usersStats.findAndModify(
         { userID: userDetails.userID },

--- a/src/schemas/voice.ts
+++ b/src/schemas/voice.ts
@@ -5,4 +5,5 @@ export interface VoiceSchema {
     id: string;
     title: string;
     url: string;
+    usesAmount: number;
 }

--- a/src/schemas/voiceStats.ts
+++ b/src/schemas/voiceStats.ts
@@ -1,8 +1,0 @@
-import { ObjectId } from "@/deps.ts";
-
-export interface VoiceStatsSchema {
-    _id: ObjectId;
-    id: string;
-    title: string;
-    usesAmount: number;
-}


### PR DESCRIPTION
- Merge `updateVoiceStats` and `updateUsersStats` method into unified `updateStats` method
- Fixed maintenance flag check (using `getFeatureFlag` instead of directly checking cache)