### PR TITLE
fix: update menu handlers for reliable work

### DIFF
--- a/src/constants/locale.ts
+++ b/src/constants/locale.ts
@@ -9,6 +9,7 @@ export const locale = {
             "Failed to get some of required environment variables. Make sure you have entered them!",
     },
     frontend: {
+        botBlocked: "Разблокируйте бота, чтобы продолжить",
         startButtonText: "Начать использование",
         startHelp: (botUsername: string) =>
             `Чтобы отправлять фразы дЕко (или декО?) или найти ту самую нужную, введи в любом другом чате мою юзерку @${botUsername} или нажми кнопку снизу`,
@@ -95,6 +96,8 @@ export const locale = {
             outdated: "Меню неактуально. Идет синхронизация...",
             failedToUpdate:
                 "Telegram не позволяет обновить это сообщение после 48 часов. Удалите сообщение вручную",
+            failedToDelete:
+                "Не удалось удалить это меню. Возможно, прошло более 48 часов, после чего, Telegram не даёт удалять мне сообщения. Удалите сообщение вручную",
             alreadyPrev: "Это и так первая страница",
             alreadyNext: "Больше новых страниц нет",
             failedToGetSessionData:

--- a/src/handlers/menu/closeMenuHandler.ts
+++ b/src/handlers/menu/closeMenuHandler.ts
@@ -1,8 +1,27 @@
 import { BotContext } from "@/src/types/bot.ts";
+import { locale } from "@/src/constants/locale.ts";
+import { isBotBlockedByUser } from "@/src/helpers/api.ts";
+
+const { botBlocked, menu: { failedToDelete } } = locale.frontend;
 
 export async function closeMenuHandler(ctx: BotContext) {
-    await ctx.deleteMessage();
+    if (await isBotBlockedByUser(ctx)) {
+        return void await ctx.answerCallbackQuery(botBlocked);
+    }
+
     ctx.session.currentFavorites = null;
     ctx.session.currentOffset = 0;
-    await ctx.answerCallbackQuery();
+
+    try {
+        await ctx.deleteMessage();
+    } catch (error: unknown) {
+        console.error(
+            `Failed to run closeMenuHandler: ${(error as Error).message}`,
+        );
+        await ctx.reply(failedToDelete, {
+            reply_to_message_id: ctx.message?.message_id,
+        });
+    } finally {
+        await ctx.answerCallbackQuery();
+    }
 }

--- a/src/handlers/menu/dynamicListHandler.ts
+++ b/src/handlers/menu/dynamicListHandler.ts
@@ -1,5 +1,5 @@
 import { MenuRange } from "@/deps.ts";
-import { BotContext } from "@/src/types/bot.ts";
+import { BotContext, MenuBotContext } from "@/src/types/bot.ts";
 import { maxMenuElementsPerPage } from "@/src/constants/inline.ts";
 import { favoriteItemHandler } from "@/src/handlers/menu/favoriteItemHandler.ts";
 import { locale } from "@/src/constants/locale.ts";
@@ -26,7 +26,8 @@ export function dynamicListHandler(
         range
             .text(
                 `${isFavoredText}${title}`,
-                async (ctx) => await favoriteItemHandler(ctx, favoriteItem),
+                async (ctx: MenuBotContext) =>
+                    await favoriteItemHandler(ctx, favoriteItem),
             )
             .row();
     }

--- a/src/handlers/menu/favoriteItemHandler.ts
+++ b/src/handlers/menu/favoriteItemHandler.ts
@@ -2,23 +2,25 @@ import { FavoriteItem, MenuBotContext } from "@/src/types/bot.ts";
 import { updateFavoriteVoiceStatus } from "@/src/helpers/cache.ts";
 import { locale } from "@/src/constants/locale.ts";
 import { updateFavoritesData } from "@/src/database/deko/usersData/updateFavoritesData.ts";
+import { isBotBlockedByUser } from "@/src/helpers/api.ts";
 
-const { inlineAnswerFail, inlineAnswerSuccess } = locale.frontend.favorites;
+const { botBlocked, favorites: { inlineAnswerFail, inlineAnswerSuccess } } =
+    locale.frontend;
 
 export async function favoriteItemHandler(
     ctx: MenuBotContext,
     favorite: FavoriteItem,
 ) {
+    if (await isBotBlockedByUser(ctx)) {
+        return void await ctx.answerCallbackQuery(botBlocked);
+    }
+
     const userID = ctx.from?.id;
     if (!userID) {
-        return await ctx.answerCallbackQuery({
+        return void await ctx.answerCallbackQuery({
             text: inlineAnswerFail,
         });
     }
-
-    await ctx.answerCallbackQuery({
-        text: inlineAnswerSuccess,
-    });
 
     const { currentFavorites } = ctx.session;
     const newFavoriteStatus = !favorite.isFavored;
@@ -35,7 +37,10 @@ export async function favoriteItemHandler(
         currentFavorites?.map((item) =>
             item.id !== favorite.id ? item : updatedFavorite
         ) ?? null;
-
     ctx.session.currentFavorites = updatedFavorites;
+
     ctx.menu.update();
+    await ctx.answerCallbackQuery({
+        text: inlineAnswerSuccess,
+    });
 }

--- a/src/handlers/menu/fingerprintHandler.ts
+++ b/src/handlers/menu/fingerprintHandler.ts
@@ -1,6 +1,5 @@
 import { BotContext } from "@/src/types/bot.ts";
 import { getMenuIdentificator } from "@/src/helpers/menu.ts";
 
-export function fingerprintHandler(ctx: BotContext) {
-    return getMenuIdentificator(ctx);
-}
+export const fingerprintHandler = (ctx: BotContext) =>
+    getMenuIdentificator(ctx);

--- a/src/handlers/menu/nextPageHandler.ts
+++ b/src/handlers/menu/nextPageHandler.ts
@@ -1,27 +1,32 @@
 import { maxMenuElementsPerPage } from "@/src/constants/inline.ts";
 import { MenuBotContext } from "@/src/types/bot.ts";
 import { locale } from "@/src/constants/locale.ts";
+import { isBotBlockedByUser } from "@/src/helpers/api.ts";
 
-const { failedToGetSessionData, alreadyNext } = locale.frontend.menu;
+const { botBlocked, menu: { failedToGetSessionData, alreadyNext } } =
+    locale.frontend;
 
 export async function nextPageHandler(ctx: MenuBotContext) {
+    if (await isBotBlockedByUser(ctx)) {
+        return void await ctx.answerCallbackQuery(botBlocked);
+    }
+
     if (!ctx.session.currentFavorites) {
-        return await ctx.answerCallbackQuery({
+        return void await ctx.answerCallbackQuery({
             text: failedToGetSessionData,
             show_alert: true,
         });
     }
 
-    await ctx.answerCallbackQuery();
-
     const newOffset = ctx.session.currentOffset + maxMenuElementsPerPage;
     if (newOffset >= ctx.session.currentFavorites.length) {
-        return ctx.answerCallbackQuery({
+        return void ctx.answerCallbackQuery({
             text: alreadyNext,
             show_alert: true,
         });
     }
-
     ctx.session.currentOffset = newOffset;
+
     ctx.menu.update();
+    await ctx.answerCallbackQuery();
 }

--- a/src/handlers/menu/outdatedHandler.ts
+++ b/src/handlers/menu/outdatedHandler.ts
@@ -1,24 +1,35 @@
 import { MenuBotContext } from "@/src/types/bot.ts";
 import { locale } from "@/src/constants/locale.ts";
+import { isBotBlockedByUser } from "@/src/helpers/api.ts";
 
-const { outdated, failedToUpdate } = locale.frontend.menu;
+const { botBlocked, menu: { outdated, failedToUpdate } } = locale.frontend;
 
 export async function outdatedHandler(ctx: MenuBotContext) {
+    if (await isBotBlockedByUser(ctx)) {
+        return void await ctx.answerCallbackQuery(botBlocked);
+    }
+
+    let isFailedToUpdate = false;
+
     try {
         if (!ctx.session.currentFavorites) {
             await ctx.deleteMessage();
-            await ctx.answerCallbackQuery();
         } else {
             ctx.menu.update();
-            await ctx.answerCallbackQuery(outdated);
         }
     } catch (error: unknown) {
+        isFailedToUpdate = true;
         console.error(
             `Failed to run outdatedHandler: ${(error as Error).message}`,
         );
         await ctx.reply(failedToUpdate, {
             reply_to_message_id: ctx.message?.message_id,
         });
-        await ctx.answerCallbackQuery();
+    } finally {
+        await ctx.answerCallbackQuery(
+            ctx.session.currentFavorites && !isFailedToUpdate
+                ? outdated
+                : undefined,
+        );
     }
 }

--- a/src/handlers/menu/prevPageHandler.ts
+++ b/src/handlers/menu/prevPageHandler.ts
@@ -1,22 +1,26 @@
 import { MenuBotContext } from "@/src/types/bot.ts";
 import { maxMenuElementsPerPage } from "@/src/constants/inline.ts";
 import { locale } from "@/src/constants/locale.ts";
+import { isBotBlockedByUser } from "@/src/helpers/api.ts";
 
-const { alreadyPrev } = locale.frontend.menu;
+const { botBlocked, menu: { alreadyPrev } } = locale.frontend;
 
 export async function prevPageHandler(ctx: MenuBotContext) {
+    if (await isBotBlockedByUser(ctx)) {
+        return void await ctx.answerCallbackQuery(botBlocked);
+    }
+
     const { currentOffset } = ctx.session;
     if (currentOffset === 0) {
-        return await ctx.answerCallbackQuery({
+        return void await ctx.answerCallbackQuery({
             text: alreadyPrev,
             show_alert: true,
         });
     }
 
-    await ctx.answerCallbackQuery();
-
     const newOffset = currentOffset - maxMenuElementsPerPage;
     ctx.session.currentOffset = newOffset < 0 ? 0 : newOffset;
 
     ctx.menu.update();
+    await ctx.answerCallbackQuery();
 }

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -1,4 +1,4 @@
-import { Api, User } from "@/deps.ts";
+import { Api, Context, User } from "@/deps.ts";
 
 import { creatorCommands } from "@/src/constants/creatorCommands.ts";
 import { userCommands } from "@/src/constants/userCommands.ts";
@@ -47,4 +47,19 @@ export function extractUserDetails(from: User | undefined) {
         fullName: getFullName(first_name, last_name),
         username,
     };
+}
+
+/**
+ * Sends chat action to check, if user blocks bot (Method throws error, if bot is blocked)
+ *
+ * @param ctx Context object to send chat action
+ * @returns Status of bot block
+ */
+export async function isBotBlockedByUser(ctx: Context) {
+    try {
+        await ctx.replyWithChatAction("typing");
+        return false;
+    } catch (_error: unknown) {
+        return true;
+    }
 }


### PR DESCRIPTION
Added checks for users, which trying to use menu after blocking the bot
Move some `answerCallbackQuery` calls (indication, that menu is responding) after main logic, so it won't be confusing for end user